### PR TITLE
Add check for extra spaces in the client id.

### DIFF
--- a/custom_components/isolarcloud/application_credentials.py
+++ b/custom_components/isolarcloud/application_credentials.py
@@ -123,13 +123,13 @@ async def async_get_auth_implementation(hass: HomeAssistant, auth_domain, creden
         server = hass.data[DOMAIN]["server"]
     else:
         server = None
-    if "@" not in credential.client_id:
+    if "@" not in credential.client_id or " " in credential.client_id:
         _LOGGER.error(
-            "Invalid client_id: %s, must be in the format <app_id>@<appkey>",
+            "Invalid client_id: %s, must be in the format <app_id>@<appkey> and must not contain spaces",
             credential.client_id,
         )
         raise ConfigEntryAuthFailed(
-            "Client_id must be in the format <app_id>@<appkey>",
+            "Client_id must be in the format <app_id>@<appkey> and must not contain spaces",
             translation_domain=DOMAIN,
             translation_key="invalid_client_id",
         )


### PR DESCRIPTION
Add a check that the client id does not have extra spaces in it.

Background: I spent a long time figuring out why the integration would not work, as I only got a dialog saying "Error" in Home Assistant after returning from the my homeassistant redirect. When I finally found the Application credentials view from HA, I noticed I had a space between the @ and appkey – probably due to a sloppy copy-paste. After removing this key and adding a new one without spaces, everything worked fine.