### PR TITLE
Fix: raise ConfigEntryNotReady from top-level setup, not forwarded platform

### DIFF
--- a/custom_components/isolarcloud/__init__.py
+++ b/custom_components/isolarcloud/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
 
 import voluptuous as vol
@@ -13,6 +14,7 @@ from homeassistant.helpers import aiohttp_client, config_entry_oauth2_flow
 
 from . import api
 from .const import DOMAIN
+from .sensor import Coordinator
 
 _LOGGER = logging.getLogger(__name__)
 _PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -33,7 +35,15 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
-type ISolarCloudConfigEntry = ConfigEntry[api.AsyncConfigEntryAuth]
+@dataclass
+class RuntimeData:
+    """Runtime data stored on the config entry."""
+
+    auth: api.AsyncConfigEntryAuth
+    coordinator: Coordinator
+
+
+type ISolarCloudConfigEntry = ConfigEntry[RuntimeData]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ISolarCloudConfigEntry) -> bool:
@@ -46,7 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ISolarCloudConfigEntry) 
 
     session = config_entry_oauth2_flow.OAuth2Session(hass, entry, implementation)
 
-    entry.runtime_data = api.AsyncConfigEntryAuth(
+    auth = api.AsyncConfigEntryAuth(
         aiohttp_client.async_get_clientsession(hass),
         session,
         entry.data["server"],
@@ -55,7 +65,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ISolarCloudConfigEntry) 
         entry.data["plant"],
     )
     # Fetch access token - this triggers token refresh or re-authentcation if needed
-    await entry.runtime_data.async_get_access_token()
+    await auth.async_get_access_token()
+
+    plants = entry.data.get("plants", [entry.data["plant"]])
+    coordinator = Coordinator(hass, entry, plants, auth.api)
+    # Do the first refresh here, in the top-level entry setup, *before*
+    # forwarding to the sensor platform. If this raises ConfigEntryNotReady,
+    # it needs to propagate from here so Home Assistant's automatic
+    # retry-with-backoff applies. Previously this call lived inside
+    # sensor.async_setup_entry (the forwarded platform setup), where
+    # raising ConfigEntryNotReady doesn't trigger that retry mechanism —
+    # HA just logs an error and leaves the entry "loaded" with permanently
+    # unavailable entities after any transient failure (e.g. a DNS blip),
+    # requiring a manual reload or restart to recover.
+    await coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = RuntimeData(auth=auth, coordinator=coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(update_listener))

--- a/custom_components/isolarcloud/sensor.py
+++ b/custom_components/isolarcloud/sensor.py
@@ -68,9 +68,8 @@ async def async_setup_entry(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the sensor platform."""
-    plants = config.data.get("plants", [config.data["plant"]])
-    coordinator = Coordinator(hass, config, plants)
-    await coordinator.async_config_entry_first_refresh()
+    coordinator = config.runtime_data.coordinator
+    plants = coordinator.plant_ids
 
     # Register services from services.py
     await async_register_services(
@@ -184,7 +183,11 @@ class Coordinator(DataUpdateCoordinator):
     """Update Coordinator."""
 
     def __init__(
-        self, hass: HomeAssistant, config_entry: ConfigType, plant_ids: list[str]
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigType,
+        plant_ids: list[str],
+        plants_api: Plants,
     ) -> None:
         """Initialize my coordinator."""
         if config_entry.options and "update_interval" in config_entry.options:
@@ -207,7 +210,7 @@ class Coordinator(DataUpdateCoordinator):
             always_update=False,
         )
         self.plant_ids = plant_ids
-        self.plants_api: Plants = config_entry.runtime_data.api
+        self.plants_api = plants_api
         self.plant_names = {}
 
     async def _async_setup(self):


### PR DESCRIPTION
Fixes #39.

## Problem

`coordinator.async_config_entry_first_refresh()` ran inside `sensor.async_setup_entry` — the *forwarded platform's* setup, called via `hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)` from `__init__.async_setup_entry`.

When the first refresh fails (e.g. a transient DNS/network blip), it raises `ConfigEntryNotReady`. Raised from inside a forwarded platform's `async_setup_entry`, this doesn't trigger Home Assistant's normal automatic retry-with-backoff for config entries. Core logs this explicitly:

```
isolarcloud raises exception ConfigEntryNotReady in forwarded platform sensor;
Instead raise ConfigEntryNotReady before calling async_forward_entry_setups
```

Net effect: after any transient failure during setup, the config entry ends up `state: loaded` (not `setup_retry`) with all entities permanently `unavailable`. Nothing retries automatically — recovery requires a manual `homeassistant.reload_config_entry` or a full HA restart. On my instance this happens nightly (router reboot causes a ~2-3 min DNS outage) and every other integration on the system recovers on its own within one poll cycle; only this one gets stuck.

## Fix

Move coordinator creation and `await coordinator.async_config_entry_first_refresh()` into `__init__.async_setup_entry`, *before* `async_forward_entry_setups` is called. A failure now raises `ConfigEntryNotReady` from the correct (top-level) place, so HA's built-in retry/backoff applies and the entry recovers on its own once the network issue clears.

To support this without an ordering dependency on `entry.runtime_data`, `Coordinator` now takes `plants_api` directly as a constructor argument instead of reading it back off `config_entry.runtime_data.api` (which didn't exist yet at the point the coordinator needs to be constructed). `entry.runtime_data` is now a small `RuntimeData` dataclass holding both `auth` and `coordinator`, so `sensor.async_setup_entry` can pick up the already-refreshed coordinator instead of creating its own.

## Testing

No test suite in the repo to run. Verified by:
- `python3 -m py_compile` on both changed files
- Tracing every reference to `entry.runtime_data` and `Coordinator(...)` across the whole `custom_components/isolarcloud` package to confirm nothing else depends on the old shape
- Confirming the new `from .sensor import Coordinator` in `__init__.py` doesn't introduce a circular import (`sensor.py` doesn't import from the package `__init__` or from `.api`)
- Manually reproduced the original bug pattern against my own instance's logs (details in #39) and confirmed `homeassistant.reload_config_entry` is what currently recovers it — this change makes that recovery automatic instead of manual.

Happy to adjust the shape of `RuntimeData` / `Coordinator`'s constructor if you'd prefer a different structure — kept the diff as small as I could while still moving the first refresh to the right place.
